### PR TITLE
Support delete requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adp_client (0.2.0)
+    adp_client (1.0.0)
       httparty
 
 GEM
@@ -10,13 +10,18 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
+    faker (1.8.7)
+      i18n (>= 0.7)
     hashdiff (0.3.7)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     multi_xml (0.6.0)
     parallel (1.12.1)
@@ -67,6 +72,7 @@ PLATFORMS
 DEPENDENCIES
   adp_client!
   bundler (~> 1.16)
+  faker
   rake (~> 10.0)
   rspec (~> 3.0)
   rspec_junit_formatter

--- a/adp_client.gemspec
+++ b/adp_client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.add_runtime_dependency 'httparty'
   spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'faker'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'

--- a/lib/adp_client.rb
+++ b/lib/adp_client.rb
@@ -120,21 +120,48 @@ class AdpClient
   end
 
   ##
-  # Get a resource
-  # Makes a request for a resource from ADP and returns the response as a
-  # raw {Hash}.
+  # Make a delete request.
+  # Makes a request to delete an existing resource from ADP.
   #
   # @param [String] the resource endpoint
-  # @return [Hash] response data
+  # @return [HTTParty::Response] the response
+  def delete(resource)
+    headers = base_headers.merge('Content-Type' => 'application/json')
+    url = "#{@base_url}/#{resource}"
+
+    @logger.debug("DELETE request Url: #{url}")
+    @logger.debug("-- Headers: #{headers}")
+
+    x = HTTParty.delete(url, headers: headers)
+    puts x.inspect
+    x
+  end
+
+  ##
+  # Make a get request
+  # Makes a request for a resource from ADP and returns the full response.
+  #
+  # @param [String] the resource endpoint
+  # @return [HTTParty::Response] the response
   def get(resource)
     url = "#{@base_url}/#{resource}"
 
     @logger.debug("GET request Url: #{url}")
     @logger.debug("-- Headers: #{base_headers}")
 
+    HTTParty.get(url, headers: base_headers)
+  end
+
+  ##
+  # Get a resource
+  # Makes a request for a resource from ADP and returns the response as a
+  # raw {Hash}.
+  #
+  # @param [String] the resource endpoint
+  # @return [Hash] response data
+  def get_resource(resource)
     raises_unless_success do
-      HTTParty
-        .get(url, headers: base_headers)
+      get(resource)
     end.parsed_response
   end
 
@@ -146,7 +173,7 @@ class AdpClient
   # @param [String] the resource endpoint
   # @param [Hash] the resource data
   # @return [Hash] response data
-  def post(resource, data)
+  def post_resource(resource, data)
     headers = base_headers
               .merge('Content-Type' => 'application/json')
     url = "#{@base_url}/#{resource}"

--- a/lib/adp_client/version.rb
+++ b/lib/adp_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AdpClient
-  VERSION = '0.2.0'
+  VERSION = '1.0.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'adp_client'
+require 'faker'
 require 'simplecov'
 
 SimpleCov.start


### PR DESCRIPTION
Add support to make delete requests to the ADP API so that consumers
may make requests to delete resources. Also includes some backwards
compatiblity breaking changes so that we can make raw get requests
that will return the whole response and not just the parsed response.
This was needed so that we can access the response headers for the
message id when querying the event notification message end points.

Closes #2